### PR TITLE
Add skipParseNumbers DSN option

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,16 @@ Default:        false
 `parseTime=true` changes the output type of `DATE` and `DATETIME` values to `time.Time` instead of `[]byte` / `string`
 The date or datetime like `0000-00-00 00:00:00` is converted into zero value of `time.Time`.
 
+##### `skipParseNumbers`
+
+```
+Type:           bool
+Valid Values:   true, false
+Default:        false
+```
+
+`skipParseNumbers=true` tells the driver not to convert integers and floats to the native go data types, and pass their
+string representation as returned by the server to `database/sql`
 
 ##### `readTimeout`
 

--- a/connection.go
+++ b/connection.go
@@ -34,6 +34,7 @@ type mysqlConn struct {
 	status           statusFlag
 	sequence         uint8
 	parseTime        bool
+	skipParseNumbers bool
 
 	// for context support (Go 1.8+)
 	watching bool

--- a/connector.go
+++ b/connector.go
@@ -85,6 +85,7 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 		connector:        c,
 	}
 	mc.parseTime = mc.cfg.ParseTime
+	mc.skipParseNumbers = mc.cfg.SkipParseNumbers
 
 	// Connect to Server
 	dialsLock.RLock()

--- a/dsn.go
+++ b/dsn.go
@@ -68,6 +68,7 @@ type Config struct {
 	InterpolateParams        bool // Interpolate placeholders into query string
 	MultiStatements          bool // Allow multiple statements in one query
 	ParseTime                bool // Parse time values to time.Time
+	SkipParseNumbers         bool // Don't parse integers and float/double values to native go types
 	RejectReadOnly           bool // Reject read-only connections
 
 	// unexported fields. new options should be come here
@@ -306,6 +307,10 @@ func (cfg *Config) FormatDSN() string {
 		writeDSNParam(&buf, &hasParam, "parseTime", "true")
 	}
 
+	if cfg.SkipParseNumbers {
+		writeDSNParam(&buf, &hasParam, "skipParseNumbers", "true")
+	}
+
 	if cfg.timeTruncate > 0 {
 		writeDSNParam(&buf, &hasParam, "timeTruncate", cfg.timeTruncate.String())
 	}
@@ -538,6 +543,14 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 		case "multiStatements":
 			var isBool bool
 			cfg.MultiStatements, isBool = readBool(value)
+			if !isBool {
+				return errors.New("invalid bool value: " + value)
+			}
+
+		// skip integer and floating point numbers parsing
+		case "skipParseNumbers":
+			var isBool bool
+			cfg.SkipParseNumbers, isBool = readBool(value)
 			if !isBool {
 				return errors.New("invalid bool value: " + value)
 			}

--- a/packets.go
+++ b/packets.go
@@ -827,22 +827,38 @@ func (rows *textRows) readRow(dest []driver.Value) error {
 			}
 
 		case fieldTypeTiny, fieldTypeShort, fieldTypeInt24, fieldTypeYear, fieldTypeLong:
-			dest[i], err = strconv.ParseInt(string(buf), 10, 64)
+			if !mc.skipParseNumbers {
+				dest[i], err = strconv.ParseInt(string(buf), 10, 64)
+			} else {
+				dest[i] = buf
+			}
 
 		case fieldTypeLongLong:
-			if rows.rs.columns[i].flags&flagUnsigned != 0 {
-				dest[i], err = strconv.ParseUint(string(buf), 10, 64)
+			if !mc.skipParseNumbers {
+				if rows.rs.columns[i].flags&flagUnsigned != 0 {
+					dest[i], err = strconv.ParseUint(string(buf), 10, 64)
+				} else {
+					dest[i], err = strconv.ParseInt(string(buf), 10, 64)
+				}
 			} else {
-				dest[i], err = strconv.ParseInt(string(buf), 10, 64)
+				dest[i] = buf
 			}
 
 		case fieldTypeFloat:
-			var d float64
-			d, err = strconv.ParseFloat(string(buf), 32)
-			dest[i] = float32(d)
+			if !mc.skipParseNumbers {
+				var d float64
+				d, err = strconv.ParseFloat(string(buf), 32)
+				dest[i] = float32(d)
+			} else {
+				dest[i] = buf
+			}
 
 		case fieldTypeDouble:
-			dest[i], err = strconv.ParseFloat(string(buf), 64)
+			if !mc.skipParseNumbers {
+				dest[i], err = strconv.ParseFloat(string(buf), 64)
+			} else {
+				dest[i] = buf
+			}
 
 		default:
 			dest[i] = buf


### PR DESCRIPTION
When the client needs string representation of the data from the database (for example, to return it in JSON from REST API), it make sense to skip conversion of the data that comes from the database server in string format.