### PR TITLE
Add GitHub workflow for automated releases on version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ inputs.tag || github.ref_name }}
-          name: SingleStore Go Driver ${{ inputs.tag || github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          name: SingleStore Go Driver ${{ github.ref_name }}
           generate_release_notes: true
           prerelease: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+      - 'v*.*.*-*'
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yml
+    secrets: inherit
+
+  release:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ inputs.tag || github.ref_name }}
+          name: SingleStore Go Driver ${{ inputs.tag || github.ref_name }}
+          generate_release_notes: true
+          prerelease: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - master
+  workflow_call:
 
 env:
   S2_TEST_USER: root


### PR DESCRIPTION
Creates releases automatically when version tags (v*.*.*[-*]) are pushed to the repo. The release workflow runs tests first and only creates a release if all tests pass. The release is created as a pre-release, then the author should update the release log to omit the irrelevant commits (build, chore) and then set as the latest reelase.

