### PR TITLE
test: add disk space cleanup script and don't rely on secrets

### DIFF
--- a/.github/scripts/clean_disk_github_runner.sh
+++ b/.github/scripts/clean_disk_github_runner.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+echo "=== BEFORE ==="
+df -h
+
+sudo rm -rf /usr/share/dotnet
+sudo rm -rf /opt/ghc
+sudo rm -rf /usr/local/share/boost
+sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+sudo rm -rf /usr/local/lib/android
+sudo rm -rf /opt/hostedtoolcache/Ruby
+
+sudo rm -rf /opt/hostedtoolcache/Java*
+sudo rm -rf /opt/hostedtoolcache/Node*
+sudo rm -rf /opt/hostedtoolcache/PyPy*
+sudo rm -rf /opt/hostedtoolcache/Swift*
+sudo rm -rf /opt/hostedtoolcache/gradle*
+sudo rm -rf /opt/hostedtoolcache/maven*
+sudo rm -rf /opt/hostedtoolcache/Rust*
+sudo rm -rf /opt/hostedtoolcache/Perl*
+sudo rm -rf /opt/hostedtoolcache/llvm
+
+sudo rm -rf /usr/local/lib/node_modules || true
+sudo rm -rf /usr/local/share/powershell || true
+sudo rm -rf /usr/local/julia* || true
+sudo rm -rf /usr/share/swift || true
+
+sudo rm -rf /var/lib/apt/lists/* || true
+sudo rm -rf /var/cache/apt/* || true
+sudo rm -rf /var/cache/man/* || true
+sudo rm -rf /var/log/* || true
+sudo rm -rf /tmp/* || true
+
+sudo apt-get update || true
+sudo apt-get purge -y \
+    azure-cli \
+    google-cloud-cli \
+    google-chrome-stable \
+    firefox \
+    powershell \
+    mono-devel \
+    hhvm \
+    php* \
+    dotnet-sdk-* \
+    temurin-* \
+    openjdk-* \
+    mysql-client* \
+    postgresql-client* \
+    || true
+
+sudo apt-get autoremove -y || true
+sudo apt-get clean || true
+
+# Uncomment if more cleanup is need, now it's commented to save time
+# docker system prune -af || true
+# docker volume prune -f || true
+
+echo "=== AFTER ==="
+df -h

--- a/.github/scripts/clean_disk_github_runner.sh
+++ b/.github/scripts/clean_disk_github_runner.sh
@@ -7,7 +7,6 @@ df -h
 sudo rm -rf /usr/share/dotnet
 sudo rm -rf /opt/ghc
 sudo rm -rf /usr/local/share/boost
-sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 sudo rm -rf /usr/local/lib/android
 sudo rm -rf /opt/hostedtoolcache/Ruby
 
@@ -52,7 +51,8 @@ sudo apt-get purge -y \
 sudo apt-get autoremove -y || true
 sudo apt-get clean || true
 
-# Uncomment if more cleanup is need, now it's commented to save time
+# Uncomment if more cleanup is needed, now it's commented to save time
+# sudo rm -rf "$AGENT_TOOLSDIRECTORY" || true
 # docker system prune -af || true
 # docker volume prune -f || true
 

--- a/.github/scripts/setup-singlestore-dev.sh
+++ b/.github/scripts/setup-singlestore-dev.sh
@@ -31,7 +31,6 @@ if [[ "${EXISTS}" -eq 0 ]]; then
         --name ${CONTAINER_NAME} \
         -v ${PWD}/.github/scripts/ssl:/test-ssl \
         -v ${PWD}/.github/scripts/jwt:/test-jwt \
-        -e SINGLESTORE_LICENSE=${SINGLESTORE_LICENSE} \
         -e ROOT_PASSWORD="${SINGLESTORE_PASSWORD}" \
         -e SINGLESTORE_VERSION=${VERSION} \
         -p ${S2_MASTER_PORT}:3306 \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Setup test cluster
         run: ./.github/scripts/setup-singlestore-dev.sh
         env:
-          ROOT_PASSWORD: ${{ steps.s2_pw.outputs.singlestore_password }}
+          S2_TEST_PASS: ${{ steps.s2_pw.outputs.singlestore_password }}
           SINGLESTORE_VERSION: ${{ matrix.singlestore_version }}
 
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ on:
 
 env:
   S2_TEST_USER: root
-  S2_TEST_PASS: ${{ secrets.SINGLESTORE_PASSWORD }}
   S2_TEST_PORT: 5506
   S2_TEST_ADDR: 127.0.0.1:5506
   S2_TEST_DB_NAME: gotest
@@ -69,6 +68,9 @@ jobs:
         with:
           ref: ${{ github.event.inputs.pr_number && format('refs/pull/{0}/merge', github.event.inputs.pr_number) || github.ref }}
 
+      - name: Clean disk on GitHub Runner
+        run: ./.github/scripts/clean_disk_github_runner.sh
+
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
@@ -83,13 +85,18 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y mysql-client
 
+      - name: Save password to output
+        id: s2_pw
+        run: echo "singlestore_password=$(openssl rand -base64 16)" >> $GITHUB_OUTPUT
+
       - name: Setup test cluster
         run: ./.github/scripts/setup-singlestore-dev.sh
         env:
-          SINGLESTORE_LICENSE: ${{ secrets.SINGLESTORE_LICENSE }}
-          ROOT_PASSWORD: ${{ secrets.SINGLESTORE_PASSWORD }}
+          ROOT_PASSWORD: ${{ steps.s2_pw.outputs.singlestore_password }}
           SINGLESTORE_VERSION: ${{ matrix.singlestore_version }}
 
       - name: Run tests
+        env:
+          S2_TEST_PASS: ${{ steps.s2_pw.outputs.singlestore_password }}
         run: |
           go test -v -race


### PR DESCRIPTION
Currently we run tests on a free dev image, no license is required to do so. Also we don't run Helios tests so no need for an API key. Therefore we can make test workflow to not depend on any secrets.