### PR TITLE
fix(dsn): escape colon in user name when formatting dsn

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -3649,6 +3649,53 @@ func runCallCommand(dbt *DBTest, query, name string) {
 	}
 }
 
+func TestSpecialCharactersInCredentials(t *testing.T) {
+	const (
+		specialUser = "my:user"
+		specialPass = ":my@pas&s"
+	)
+
+	// Connect as admin to create the user
+	adminDB, err := sql.Open(driverNameTest, dsn)
+	if err != nil {
+		t.Fatalf("error connecting as admin: %s", err)
+	}
+	defer adminDB.Close()
+
+	if _, err = adminDB.Exec("DROP USER IF EXISTS ?@'%'", specialUser); err != nil {
+		t.Fatalf("error dropping user: %s", err)
+	}
+
+	if _, err = adminDB.Exec("CREATE USER ?@'%' IDENTIFIED BY ?", specialUser, specialPass); err != nil {
+		t.Fatalf("error creating user: %s", err)
+	}
+	defer adminDB.Exec("DROP USER ?@'%'", specialUser)
+
+	// Build config directly and derive a DSN from it
+	cfg := NewConfig()
+	cfg.Net = prot
+	cfg.Addr = addr
+	cfg.User = specialUser
+	cfg.Passwd = specialPass
+
+	specialDSN := cfg.FormatDSN()
+	t.Logf("DSN with special characters: %s", specialDSN)
+
+	db2, err := sql.Open(driverNameTest, specialDSN)
+	if err != nil {
+		t.Fatalf("error opening db with special-character DSN: %s", err)
+	}
+	defer db2.Close()
+
+	var currentUser string
+	if err := db2.QueryRow("SELECT CURRENT_USER()").Scan(&currentUser); err != nil {
+		t.Fatalf("error querying with special-character credentials: %s", err)
+	}
+	if !strings.HasPrefix(currentUser, specialUser) {
+		t.Errorf("expected current user to start with %q, got %q", specialUser, currentUser)
+	}
+}
+
 func TestIssue1567(t *testing.T) {
 	// enable TLS.
 	runTests(t, dsn+"&tls=skip-verify", func(dbt *DBTest) {

--- a/dsn.go
+++ b/dsn.go
@@ -257,10 +257,11 @@ func (cfg *Config) FormatDSN() string {
 
 	// [username[:password]@]
 	if len(cfg.User) > 0 {
-		buf.WriteString(cfg.User)
+		// Encode ':' in username so it is not confused with the user:passwd separator.
+		buf.WriteString(url.QueryEscape(cfg.User))
 		if len(cfg.Passwd) > 0 {
 			buf.WriteByte(':')
-			buf.WriteString(cfg.Passwd)
+			buf.WriteString(url.QueryEscape(cfg.Passwd))
 		}
 		buf.WriteByte('@')
 	}
@@ -425,11 +426,17 @@ func ParseDSN(dsn string) (cfg *Config, err error) {
 						// Find the first ':' in dsn[:j]
 						for k = 0; k < j; k++ {
 							if dsn[k] == ':' {
-								cfg.Passwd = dsn[k+1 : j]
+								passwd := dsn[k+1 : j]
+								if cfg.Passwd, err = url.QueryUnescape(passwd); err != nil {
+									return nil, fmt.Errorf("invalid passwd %q: %w", passwd, err)
+								}
 								break
 							}
 						}
-						cfg.User = dsn[:k]
+						user := dsn[:k]
+						if cfg.User, err = url.QueryUnescape(user); err != nil {
+							return nil, fmt.Errorf("invalid user %q: %w", user, err)
+						}
 
 						break
 					}

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -83,6 +83,9 @@ var testDSNs = []struct {
 }, {
 	"tcp(127.0.0.1)/dbname?ctxCancellationEnabled=true",
 	&Config{Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname", Loc: time.UTC, MaxAllowedPacket: defaultMaxAllowedPacket, Logger: defaultLogger, AllowNativePasswords: true, CheckConnLiveness: true, CtxCancellationEnabled: true},
+}, {
+	"us%3Aer:password@tcp(localhost:3306)/dbname",
+	&Config{User: "us:er", Passwd: "password", Net: "tcp", Addr: "localhost:3306", DBName: "dbname", Loc: time.UTC, MaxAllowedPacket: defaultMaxAllowedPacket, Logger: defaultLogger, AllowNativePasswords: true, CheckConnLiveness: true},
 },
 }
 
@@ -427,6 +430,96 @@ func TestNormalizeTLSConfig(t *testing.T) {
 			if cfg.TLS.InsecureSkipVerify != tc.want.InsecureSkipVerify {
 				t.Errorf("tls.InsecureSkipVerify doesn't match (want: %T, got :%T)",
 					tc.want.InsecureSkipVerify, cfg.TLS.InsecureSkipVerify)
+			}
+		})
+	}
+}
+
+func TestDSNUsernameWithColon(t *testing.T) {
+	testCases := []struct {
+		name string
+		user string
+	}{
+		{"colon in username", "us:er"},
+		{"multiple colons", "a:b:c"},
+		{"leading colon", ":user"},
+		{"trailing colon", "user:"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := NewConfig()
+			cfg.User = tc.user
+			cfg.Passwd = "password"
+			cfg.Net = "tcp"
+			cfg.Addr = "localhost:3306"
+			cfg.DBName = "testdb"
+
+			dsn := cfg.FormatDSN()
+
+			parsed, err := ParseDSN(dsn)
+			if err != nil {
+				t.Fatalf("failed to parse DSN %q: %v", dsn, err)
+			}
+
+			if parsed.User != tc.user {
+				t.Errorf("user mismatch: got %q, want %q (DSN: %s)", parsed.User, tc.user, dsn)
+			}
+
+			if parsed.Passwd != "password" {
+				t.Errorf("passwd mismatch: got %q, want %q (DSN: %s)", parsed.Passwd, "password", dsn)
+			}
+
+			dsn2 := parsed.FormatDSN()
+			if dsn != dsn2 {
+				t.Errorf("DSN not stable after round-trip: got %q, want %q", dsn2, dsn)
+			}
+		})
+	}
+}
+
+func TestDSNPasswordSpecialChars(t *testing.T) {
+	testCases := []struct {
+		name     string
+		password string
+	}{
+		{"at sign", "p@ssword"},
+		{"ampersand", "p&ssword"},
+		{"multiple at signs", "p@ss@word"},
+		{"multiple ampersands", "p&ss&word"},
+		{"at and ampersand", "p@ss&word"},
+		{"complex special chars", "p@ss&w@rd&test=value"},
+		{"looks like query param", "pass&key=value&other=123"},
+		{"slash in password", "p/ss/word"},
+		{"at slash and ampersand", "p@/ss&word"},
+		{"colon in password", "p:assword"},
+		{"question mark", "p?ssword"},
+		{"equals sign", "pass=word"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := NewConfig()
+			cfg.User = "testuser"
+			cfg.Passwd = tc.password
+			cfg.Net = "tcp"
+			cfg.Addr = "localhost:3306"
+			cfg.DBName = "testdb"
+
+			dsn := cfg.FormatDSN()
+
+			parsed, err := ParseDSN(dsn)
+			if err != nil {
+				t.Fatalf("failed to parse DSN %q: %v", dsn, err)
+			}
+
+			if parsed.Passwd != tc.password {
+				t.Errorf("password mismatch: got %q, want %q (DSN: %s)", parsed.Passwd, tc.password, dsn)
+			}
+
+			dsn2 := parsed.FormatDSN()
+			if dsn != dsn2 {
+				t.Errorf("DSN not stable after round-trip: got %q, want %q", dsn2, dsn)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core DSN formatting/parsing used by all connections; behavior changes for usernames/passwords containing reserved characters and could affect users relying on previously unescaped/escaped forms.
> 
> **Overview**
> Fixes DSN handling for credentials containing reserved characters by **URL-escaping `Config.User` and `Config.Passwd` in `FormatDSN`** and **URL-unescaping them in `ParseDSN`** (with clearer errors on invalid escapes).
> 
> Adds coverage to prevent regressions: new DSN parser/round-trip tests for colons in usernames and many special characters in passwords, plus an integration test that creates a user with special-character credentials and verifies it can connect using the generated DSN.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e398e3607f0a6fa9e1458c71e4d8049e714b65b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->