### PR TITLE
fix: resolve potential buffer re-use in getSystemVar

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -450,8 +450,7 @@ func (mc *mysqlConn) query(query string, args []driver.Value) (*textRows, error)
 	return rows, err
 }
 
-// Gets the value of the given MySQL System Variable
-// The returned byte slice is only valid until the next read
+// Gets the value of the given System Variable
 func (mc *mysqlConn) getSystemVar(name string) ([]byte, error) {
 	// Send command
 	handleOk := mc.clearResult()
@@ -475,7 +474,11 @@ func (mc *mysqlConn) getSystemVar(name string) ([]byte, error) {
 
 		dest := make([]driver.Value, resLen)
 		if err = rows.readRow(dest); err == nil {
-			return dest[0].([]byte), mc.readUntilEOF()
+			// Copy the result before readUntilEOF since it may reuse the buffer
+			val := dest[0].([]byte)
+			result := make([]byte, len(val))
+			copy(result, val)
+			return result, mc.readUntilEOF()
 		}
 	}
 	return nil, err


### PR DESCRIPTION
We've got the following sequence of function calls: `getSystemVar` -> `readRow` -> `readPacket` -> `readNext`, and `readUntilEOF` -> `readPacket` -> `readNext`. `readNext` function comment says "The returned slice is only guaranteed to be valid until the next read". It is therefore not right to return `(readRow result, readUntilEOF result)` from the function without copying `readRow` result, as readUntilEOF may overwrite it.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches low-level result parsing in the MySQL driver; while the change is small, it affects how system-variable queries return bytes and could impact callers relying on previous buffer behavior.
> 
> **Overview**
> Fixes `getSystemVar` to **return a stable `[]byte`** by copying the value read from `readRow` before calling `readUntilEOF`, preventing later reads from reusing/overwriting the underlying buffer.
> 
> Also updates the comment to remove the MySQL-specific wording and documents why the copy is required.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa11f0c35f0e62e13b2d1a67a0afd1b4e4cef0b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->