### PR TITLE
test: run TestConcurrent

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ env:
   S2_TEST_PORT: 5506
   S2_TEST_ADDR: 127.0.0.1:5506
   S2_TEST_DB_NAME: gotest
-  S2_TEST_CONCURRENT: 0
+  S2_TEST_CONCURRENT: 1
 
 jobs:
   fetch-s2-versions:
@@ -99,4 +99,10 @@ jobs:
         env:
           S2_TEST_PASS: ${{ steps.s2_pw.outputs.singlestore_password }}
         run: |
-          go test -v -race
+          go test -v -race -covermode=atomic -coverprofile=coverage.out -parallel 10
+
+      - name: Run benchmark
+        env:
+          S2_TEST_PASS: ${{ steps.s2_pw.outputs.singlestore_password }}
+        run: |
+          go test -run '^$' -bench .

--- a/driver_test.go
+++ b/driver_test.go
@@ -1975,17 +1975,19 @@ func TestConcurrent(t *testing.T) {
 
 	runTests(t, dsn, func(dbt *DBTest) {
 
-		var max int
-		err := dbt.db.QueryRow("SELECT @@max_connections").Scan(&max)
+		var maxConnections int
+		err := dbt.db.QueryRow("SELECT @@max_connections").Scan(&maxConnections)
 		if err != nil {
 			dbt.Fatalf("%s", err.Error())
 		}
-		dbt.Logf("testing up to %d concurrent connections \r\n", max)
+		// not testing more than 2048 concurrent connections as we are on a small database cluster
+		maxConnections = min(maxConnections, 2048)
+		dbt.Logf("testing up to %d concurrent connections \r\n", maxConnections)
 
-		var remaining, succeeded int32 = int32(max), 0
+		var remaining, succeeded int32 = int32(maxConnections), 0
 
 		var wg sync.WaitGroup
-		wg.Add(max)
+		wg.Add(maxConnections)
 
 		var fatalError string
 		var once sync.Once
@@ -1995,7 +1997,7 @@ func TestConcurrent(t *testing.T) {
 			})
 		}
 
-		for i := 0; i < max; i++ {
+		for i := 0; i < maxConnections; i++ {
 			go func(id int) {
 				defer wg.Done()
 


### PR DESCRIPTION
Enable benchmarks and concurrency test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI now runs `TestConcurrent` and benchmarks, and increases test parallelism/coverage settings, which can change runtime and introduce flakiness due to load and timing sensitivity on small test clusters.
> 
> **Overview**
> Enables concurrency coverage in CI by default by setting `S2_TEST_CONCURRENT=1`, causing `TestConcurrent` to run in the GitHub Actions workflow.
> 
> Updates the test job to collect Go coverage output and run tests with higher parallelism, and adds a separate step to execute `go test` benchmarks. `TestConcurrent` is adjusted to cap the attempted concurrent connections at 2048 to avoid overwhelming the small CI database cluster.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e57630ab6fb2e03dd29bd0e34bdb5ce64a890b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->