### PR TITLE
feat!: rename driver to singlestore

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,8 +77,9 @@ jobs:
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
+        if: matrix.go == '1.25'
         with:
-          version: v2.8.0
+          version: v2.12.2
 
       - name: Install MySQL client
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
           S2_VERSIONS: ${{ needs.fetch-s2-versions.outputs.versions }}
         run: |
           import itertools, json, os
-          go_versions = ["1.21", "1.22", "1.23", "1.24"]
+          go_versions = ["1.24", "1.25", "1.26"]
           s2_versions = json.loads(os.environ['S2_VERSIONS'])
           if len(go_versions) <= len(s2_versions):
             pairs = list(zip(itertools.cycle(go_versions), s2_versions))

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         if: matrix.go == '1.25'
         with:
-          version: v2.12.2
+          version: v2.8.0
 
       - name: Install MySQL client
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@
 - The module path moved from `github.com/memsql/go-singlestore-driver` to `github.com/singlestore-labs/go-singlestore-driver`. Update import paths and `go.mod` accordingly. See [MIGRATION.md](MIGRATION.md).
 - The Go package name is now `singlestore` (was `mysql`). Named imports must be updated; the exported driver type is renamed `MySQLDriver` -> `SingleStoreDriver`.
 - The driver registered with `database/sql` now uses the name `singlestore` instead of `mysql`. Update `sql.Open("mysql", dsn)` to `sql.Open("singlestore", dsn)`. This avoids init-time conflicts when both this module and `github.com/go-sql-driver/mysql` are imported.
+
+### Additional changes
 - Driver-emitted error messages that used the `mysql:` prefix now use `singlestore:` (for example unsupported isolation level and named parameters).
 - Minimum Go version is now 1.24.
+- Set `_client_name` connection attribute to `singlestore-labs/go-singlestore-driver`.
+
 
 ## Version 1.9.3-p0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@
 
 ### Breaking changes
 
-- The driver registered with `database/sql` now uses the name `singlestore` instead of `mysql`. Update `sql.Open("mysql", dsn)` to `sql.Open("singlestore", dsn)`. This avoids init-time conflicts when both this module and `github.com/go-sql-driver/mysql` are imported. See [MIGRATION.md](MIGRATION.md).
+- The module path moved from `github.com/memsql/go-singlestore-driver` to `github.com/singlestore-labs/go-singlestore-driver`. Update import paths and `go.mod` accordingly. See [MIGRATION.md](MIGRATION.md).
+- The Go package name is now `singlestore` (was `mysql`). Named imports must be updated; the exported driver type is renamed `MySQLDriver` -> `SingleStoreDriver`.
+- The driver registered with `database/sql` now uses the name `singlestore` instead of `mysql`. Update `sql.Open("mysql", dsn)` to `sql.Open("singlestore", dsn)`. This avoids init-time conflicts when both this module and `github.com/go-sql-driver/mysql` are imported.
 - Driver-emitted error messages that used the `mysql:` prefix now use `singlestore:` (for example unsupported isolation level and named parameters).
+- Minimum Go version is now 1.24.
 
 ## Version 1.9.3-p0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Breaking changes
+
+- The driver registered with `database/sql` now uses the name `singlestore` instead of `mysql`. Update `sql.Open("mysql", dsn)` to `sql.Open("singlestore", dsn)`. This avoids init-time conflicts when both this module and `github.com/go-sql-driver/mysql` are imported. See [MIGRATION.md](MIGRATION.md).
+- Driver-emitted error messages that used the `mysql:` prefix now use `singlestore:` (for example unsupported isolation level and named parameters).
+
 ## Version 1.9.3-p0
 
 - disable fetch connection info for kill connection (#10)

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -5,14 +5,12 @@ This driver registers with `database/sql` as **`singlestore`**, package name is 
 ## Core changes
 
 
-1. **Module**
-   Replace the old module path `github.com/go-sql-driver/mysql` (or `github.com/memsql/go-singlestore-driver`) with `github.com/singlestore-labs/go-singlestore-driver`:
+1. **Module** — pin the new module path (optional; `goimports` / `go build` can add it once imports exist):
    ```bash
    # Pin a released semver tag:
    go get github.com/singlestore-labs/go-singlestore-driver@v2.0.0
    # or pin a specific commit (Go produces a v0.0.0-<date>-<sha> pseudo-version):
    go get github.com/singlestore-labs/go-singlestore-driver@abcdef1234567890
-   go mod tidy
    ```
 
 2. **Blank import** registers the driver. Replace `github.com/go-sql-driver/mysql` or `github.com/memsql/go-singlestore-driver` with
@@ -45,13 +43,20 @@ This driver registers with `database/sql` as **`singlestore`**, package name is 
 
    cfg, err := s2driver.ParseDSN(dsn)
    ```
-   The blank import and the aliased import can coexist in the same file — the blank form only triggers `init()`, the alias gives you a usable name.
+   The blank import and the aliased import can coexist in the same file.
 
-5. **Operational tooling** — driver name in metrics is now `singlestore`; default log prefix is `[singlestore]`; some client-side error strings use a `singlestore:` prefix.
+5. **Reconcile `go.mod`** — after steps 2–4 (and any mechanical rewrites / `goimports` below):
+   ```bash
+   go mod tidy
+   go build ./...
+   ```
+   This drops the old driver module from `go.mod` once nothing imports it, and keeps the new module because your code now references it.
 
-6. **DSN review** — consider SingleStore-specific flags (e.g. `ctxCancellationEnabled=true`); avoid MySQL-only knobs that are no-ops here (`rejectReadOnly`, `serverPubKey`,...). See [README](README.md).
+6. **Operational tooling** — driver name in metrics is now `singlestore`; default log prefix is `[singlestore]`; some client-side error strings use a `singlestore:` prefix.
 
-7. **ORMs/frameworks** - Point ORMs/frameworks that hardcode `"mysql"` at `"singlestore"` or inject a pre-built `*sql.DB`. For example, if you are using `github.com/jmoiron/sqlx`:
+7. **DSN review** — consider SingleStore-specific flags (e.g. `ctxCancellationEnabled=true`); avoid MySQL-only knobs that are no-ops here (`rejectReadOnly`, `serverPubKey`,...). See [README](README.md).
+
+8. **ORMs/frameworks** - Point ORMs/frameworks that hardcode `"mysql"` at `"singlestore"` or inject a pre-built `*sql.DB`. For example, if you are using `github.com/jmoiron/sqlx`:
    ```go
    // before
    db, err := sqlx.Open("mysql", connString)
@@ -73,7 +78,7 @@ gofmt -r 'mysql.ParseDSN(a) -> singlestore.ParseDSN(a)' -w .
 # etc.
 ```
 
-After any rewrite, run `goimports -w .` (or `go build ./...`) to fix up imports.
+After any rewrite, run `goimports -w .` to fix up imports, then step 5 (`go mod tidy` and `go build ./...`).
 
 ### Verify
 
@@ -97,7 +102,7 @@ git grep -nE '(driverName|driver)\s*[:=]\s*"mysql"' '*.go'  # constants/vars hol
 
 ### `go.sum` and indirect dependencies
 
-After migration you may still see `github.com/go-sql-driver/mysql` listed as an **indirect** dependency in `go.mod` / `go.sum` — for example, pulled in by `github.com/jmoiron/sqlx`'s test code or by another module you depend on. This is harmless: the indirect entry only records that some transitive dependency references the package, and because nothing in your application registers it as a `database/sql` driver, there is no init-time conflict with `singlestore`. Run `go mod tidy` after migration to drop any entries that are no longer needed; if `go-sql-driver/mysql` remains, you can leave it in place.
+After step 5 you may still see `github.com/go-sql-driver/mysql` listed as an **indirect** dependency in `go.mod` / `go.sum` — for example, pulled in by `github.com/jmoiron/sqlx`'s test code or by another module you depend on. This is harmless: the indirect entry only records that some transitive dependency references the package, and because nothing in your application registers it as a `database/sql` driver, there is no init-time conflict with `singlestore`. If `go-sql-driver/mysql` remains after `go mod tidy`, you can leave it in place.
 
 ### Getting help
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,110 @@
+# Migration guide
+
+This driver registers with `database/sql` as **`singlestore`**, package name is now `singlestore`. Earlier releases — and the upstream [Go-MySQL-Driver](https://github.com/go-sql-driver/mysql) — register as `mysql`. Migrating means renaming both the driver string and the package name.
+
+## Core changes
+
+
+1. **Module**
+   Replace the old module path `github.com/go-sql-driver/mysql` (or `github.com/memsql/go-singlestore-driver`) with `github.com/singlestore-labs/go-singlestore-driver`:
+   ```bash
+   # Pin a released semver tag:
+   go get github.com/singlestore-labs/go-singlestore-driver@v2.0.0
+   # or pin a specific commit (Go produces a v0.0.0-<date>-<sha> pseudo-version):
+   go get github.com/singlestore-labs/go-singlestore-driver@abcdef1234567890
+   go mod tidy
+   ```
+
+2. **Blank import** registers the driver. Replace `github.com/go-sql-driver/mysql` or `github.com/memsql/go-singlestore-driver` with
+   ```go
+   _ "github.com/singlestore-labs/go-singlestore-driver"
+   ```
+   The blank import does not bind the package name, so it does **not** conflict with a named import of the same module elsewhere in the file (see point 4 and the package-name collision note below).
+
+3. **`sql.Open`** — change the driver name for SingleStore call sites:
+   ```go
+   sql.Open("singlestore", dsn)
+   ```
+
+4. **Named imports** — rename the package prefix on symbols from this module:
+   ```go
+   import "github.com/singlestore-labs/go-singlestore-driver" // package singlestore
+
+   singlestore.ParseDSN(dsn)
+   singlestore.NewConnector(cfg)
+   // *singlestore.MySQLError, singlestore.Config, singlestore.Result, …
+   ```
+   Identifiers are unchanged from upstream — only the prefix moves.
+
+   **Package-name collision.** If your own code lives in a package named `singlestore` (common in repos that wrap this driver), the bare `singlestore.X` form is ambiguous. Use an import alias instead:
+   ```go
+   import (
+       _ "github.com/singlestore-labs/go-singlestore-driver" // register driver
+       s2driver "github.com/singlestore-labs/go-singlestore-driver"
+   )
+
+   cfg, err := s2driver.ParseDSN(dsn)
+   ```
+   The blank import and the aliased import can coexist in the same file — the blank form only triggers `init()`, the alias gives you a usable name.
+
+5. **Operational tooling** — driver name in metrics is now `singlestore`; default log prefix is `[singlestore]`; some client-side error strings use a `singlestore:` prefix.
+
+6. **DSN review** — consider SingleStore-specific flags (e.g. `ctxCancellationEnabled=true`); avoid MySQL-only knobs that are no-ops here (`rejectReadOnly`, `serverPubKey`,...). See [README](README.md).
+
+7. **ORMs/frameworks** - Point ORMs/frameworks that hardcode `"mysql"` at `"singlestore"` or inject a pre-built `*sql.DB`. For example, if you are using `github.com/jmoiron/sqlx`:
+   ```go
+   // before
+   db, err := sqlx.Open("mysql", connString)
+   // after
+   db, err := sqlx.Open("singlestore", connString)
+   ```
+   The same rename applies to `sqlx.MustOpen`, `sqlx.Connect`, and `sqlx.MustConnect`.
+
+### Mechanical rewrites
+
+For larger codebases, the package-prefix rename can be automated. `gofmt -r` is safe (AST-aware) and preferred over `sed`:
+
+```bash
+# Rewrite all mysql.X references from this driver to singlestore.X.
+# Repeat per identifier, or script a loop over the lists in the Verify section.
+gofmt -r 'mysql.ErrNoTLS -> singlestore.ErrNoTLS' -w .
+gofmt -r 'mysql.MySQLError -> singlestore.MySQLError' -w .
+gofmt -r 'mysql.ParseDSN(a) -> singlestore.ParseDSN(a)' -w .
+# …etc.
+```
+
+If you need a quick `sed` pass (e.g. for non-Go files like comments or docs), scope it tightly so you don't rewrite unrelated `mysql.` strings:
+
+```bash
+git ls-files '*.go' | xargs sed -i '' 's/\bmysql\.ErrNoTLS\b/singlestore.ErrNoTLS/g'
+```
+
+After any rewrite, run `goimports -w .` (or `go build ./...`) to fix up imports.
+
+### Verify
+
+Check that the necessary changes have been applied.
+```bash
+git grep 'go-sql-driver/mysql' '*.go'  # SingleStore call sites should be gone
+# Catches sql.Open, sqlx.Open, sqlx.MustOpen, sqlx.Connect, sqlx.MustConnect, and similar wrappers:
+git grep -E '\.(Open|MustOpen|Connect|MustConnect)\("mysql"' '*.go'
+git grep 'github\.com/memsql/go-singlestore-driver'  # old module name should be gone
+git grep -E 'mysql\.(BeforeConnect|Charset|DeregisterDialContext|DeregisterLocalFile|DeregisterReaderHandler|DeregisterServerPubKey|DeregisterTLSConfig|EnableCompression|NewConfig|NewConnector|ParseDSN|RegisterDial|RegisterDialContext|RegisterLocalFile|RegisterReaderHandler|RegisterServerPubKey|RegisterTLSConfig|SetLogger|TimeTruncate)([^[:alnum:]_]|$)' '*.go'  # old package prefix on functions should be gone
+git grep -E 'mysql\.(Config|DialContextFunc|DialFunc|Logger|MySQLError|NopLogger|NullTime|Option|Result|SingleStoreDriver)([^[:alnum:]_]|$)' '*.go'  # old package prefix on types should be gone
+git grep -E 'mysql\.(ErrBusyBuffer|ErrCleartextPassword|ErrInvalidConn|ErrMalformPkt|ErrNativePassword|ErrNoTLS|ErrOldPassword|ErrOldProtocol|ErrPktSync|ErrPktSyncMul|ErrPktTooLarge|ErrUnknownPlugin)([^[:alnum:]_]|$)' '*.go'  # old package prefix on exported errors should be gone
+```
+
+Also audit any indirection through a variable or constant — these won't be caught by the grep above:
+
+```bash
+git grep -nE '"mysql"' '*.go'                               # any remaining string literal
+git grep -nE '(driverName|driver)\s*[:=]\s*"mysql"' '*.go'  # constants/vars holding the old name
+```
+
+### `go.sum` and indirect dependencies
+
+After migration you may still see `github.com/go-sql-driver/mysql` listed as an **indirect** dependency in `go.mod` / `go.sum` — for example, pulled in by `github.com/jmoiron/sqlx`'s test code or by another module you depend on.
+
+### Getting help
+
+Open an issue on [go-singlestore-driver](https://github.com/singlestore-labs/go-singlestore-driver).

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -34,7 +34,7 @@ This driver registers with `database/sql` as **`singlestore`**, package name is 
    singlestore.NewConnector(cfg)
    // *singlestore.MySQLError, singlestore.Config, singlestore.Result, …
    ```
-   Identifiers are unchanged from upstream — only the prefix moves.
+   Most of the identifiers are unchanged from upstream — only the prefix moves. The notable exception is `MySQLDriver` -> `SingleStoreDriver`.
 
    **Package-name collision.** If your own code lives in a package named `singlestore` (common in repos that wrap this driver), the bare `singlestore.X` form is ambiguous. Use an import alias instead:
    ```go
@@ -90,7 +90,7 @@ git grep 'go-sql-driver/mysql' '*.go'  # SingleStore call sites should be gone
 git grep -E '\.(Open|MustOpen|Connect|MustConnect)\("mysql"' '*.go'
 git grep 'github\.com/memsql/go-singlestore-driver'  # old module name should be gone
 git grep -E 'mysql\.(BeforeConnect|Charset|DeregisterDialContext|DeregisterLocalFile|DeregisterReaderHandler|DeregisterServerPubKey|DeregisterTLSConfig|EnableCompression|NewConfig|NewConnector|ParseDSN|RegisterDial|RegisterDialContext|RegisterLocalFile|RegisterReaderHandler|RegisterServerPubKey|RegisterTLSConfig|SetLogger|TimeTruncate)([^[:alnum:]_]|$)' '*.go'  # old package prefix on functions should be gone
-git grep -E 'mysql\.(Config|DialContextFunc|DialFunc|Logger|MySQLError|NopLogger|NullTime|Option|Result|SingleStoreDriver)([^[:alnum:]_]|$)' '*.go'  # old package prefix on types should be gone
+git grep -E 'mysql\.(Config|DialContextFunc|DialFunc|Logger|MySQLError|NopLogger|NullTime|Option|Result|MySQLDriver)([^[:alnum:]_]|$)' '*.go'  # old package prefix on types should be gone
 git grep -E 'mysql\.(ErrBusyBuffer|ErrCleartextPassword|ErrInvalidConn|ErrMalformPkt|ErrNativePassword|ErrNoTLS|ErrOldPassword|ErrOldProtocol|ErrPktSync|ErrPktSyncMul|ErrPktTooLarge|ErrUnknownPlugin)([^[:alnum:]_]|$)' '*.go'  # old package prefix on exported errors should be gone
 ```
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -32,7 +32,7 @@ This driver registers with `database/sql` as **`singlestore`**, package name is 
 
    singlestore.ParseDSN(dsn)
    singlestore.NewConnector(cfg)
-   // *singlestore.MySQLError, singlestore.Config, singlestore.Result, …
+   // *singlestore.MySQLError, singlestore.Config, singlestore.Result, ...
    ```
    Most of the identifiers are unchanged from upstream — only the prefix moves. The notable exception is `MySQLDriver` -> `SingleStoreDriver`.
 
@@ -70,13 +70,7 @@ For larger codebases, the package-prefix rename can be automated. `gofmt -r` is 
 gofmt -r 'mysql.ErrNoTLS -> singlestore.ErrNoTLS' -w .
 gofmt -r 'mysql.MySQLError -> singlestore.MySQLError' -w .
 gofmt -r 'mysql.ParseDSN(a) -> singlestore.ParseDSN(a)' -w .
-# …etc.
-```
-
-If you need a quick `sed` pass (e.g. for non-Go files like comments or docs), scope it tightly so you don't rewrite unrelated `mysql.` strings:
-
-```bash
-git ls-files '*.go' | xargs sed -i '' 's/\bmysql\.ErrNoTLS\b/singlestore.ErrNoTLS/g'
+# etc.
 ```
 
 After any rewrite, run `goimports -w .` (or `go build ./...`) to fix up imports.
@@ -103,7 +97,7 @@ git grep -nE '(driverName|driver)\s*[:=]\s*"mysql"' '*.go'  # constants/vars hol
 
 ### `go.sum` and indirect dependencies
 
-After migration you may still see `github.com/go-sql-driver/mysql` listed as an **indirect** dependency in `go.mod` / `go.sum` — for example, pulled in by `github.com/jmoiron/sqlx`'s test code or by another module you depend on.
+After migration you may still see `github.com/go-sql-driver/mysql` listed as an **indirect** dependency in `go.mod` / `go.sum` — for example, pulled in by `github.com/jmoiron/sqlx`'s test code or by another module you depend on. This is harmless: the indirect entry only records that some transitive dependency references the package, and because nothing in your application registers it as a `database/sql` driver, there is no init-time conflict with `singlestore`. Run `go mod tidy` after migration to drop any entries that are no longer needed; if `go-sql-driver/mysql` remains, you can leave it in place.
 
 ### Getting help
 

--- a/README.md
+++ b/README.md
@@ -24,13 +24,14 @@ This driver is a fork of [Go-MySQL-Driver](https://github.com/go-sql-driver/mysq
     * [Unicode support](#unicode-support)
   * [Testing / Development](#testing--development)
   * [License](#license)
+  * [Migration](MIGRATION.md)
 
 ---------------------------------------
 
 ## Features
   * Lightweight and fast
   * Native Go implementation. No C-bindings, just pure Go
-  * Connections over TCP/IPv4, TCP/IPv6, Unix domain sockets or [custom protocols](https://godoc.org/github.com/memsql/go-singlestore-driver#DialFunc)
+  * Connections over TCP/IPv4, TCP/IPv6, Unix domain sockets or [custom protocols](https://godoc.org/github.com/singlestore-labs/go-singlestore-driver#DialFunc)
   * Automatic handling of broken connections
   * Automatic Connection Pooling *(by database/sql package)*
   * Supports queries larger than 16MB
@@ -69,26 +70,26 @@ This driver is a fork of [go-sql-driver/mysql](https://github.com/go-sql-driver/
 ## Installation
 Install the package to your [$GOPATH](https://github.com/golang/go/wiki/GOPATH "GOPATH") with the [go tool](https://golang.org/cmd/go/ "go command") from shell:
 ```bash
-go get -u github.com/memsql/go-singlestore-driver
+go get -u github.com/singlestore-labs/go-singlestore-driver
 ```
 Make sure [Git is installed](https://git-scm.com/downloads) on your machine and in your system's `PATH`.
 
 ## Usage
 _Go SingleStore Driver_ is an implementation of Go's `database/sql/driver` interface. Once you import the driver, you can access the full [`database/sql`](https://golang.org/pkg/database/sql/) API.
 
-Use `mysql` as `driverName` and a valid [DSN](#dsn-data-source-name) as `dataSourceName`:
+Use `singlestore` as `driverName` and a valid [DSN](#dsn-data-source-name) as `dataSourceName`:
 
 ```go
 import (
 	"database/sql"
 	"time"
 
-	_ "github.com/memsql/go-singlestore-driver"
+	_ "github.com/singlestore-labs/go-singlestore-driver"
 )
 
 // ...
 
-db, err := sql.Open("mysql", "user:password@/dbname")
+db, err := sql.Open("singlestore", "user:password@/dbname")
 if err != nil {
 	panic(err)
 }
@@ -139,7 +140,7 @@ This has the same effect as an empty DSN string:
 /dbname%2Fwithslash
 ```
 
-Alternatively, [Config.FormatDSN](https://godoc.org/github.com/memsql/go-singlestore-driver#Config.FormatDSN) can be used to create a DSN string by filling a struct.
+Alternatively, [Config.FormatDSN](https://godoc.org/github.com/singlestore-labs/go-singlestore-driver#Config.FormatDSN) can be used to create a DSN string by filling a struct.
 
 #### Password
 Passwords can consist of any character. Escaping is **not** necessary.
@@ -345,19 +346,30 @@ Allow multiple statements in one query. This can be used to batch multiple queri
 
 When `multiStatements` is used, `?` parameters must only be used in the first statement. [interpolateParams](#interpolateparams) can be used to avoid this limitation unless prepared statement is used explicitly.
 
-It's possible to access the last inserted ID and number of affected rows for multiple statements by using `sql.Conn.Raw()` and the `mysql.Result`. For example:
+It's possible to access the last inserted ID and number of affected rows for multiple statements by using `sql.Conn.Raw()` and the `singlestore.Result` interface. For example:
 
 ```go
+import (
+	"database/sql/driver"
+	"log"
+
+	"github.com/singlestore-labs/go-singlestore-driver"
+)
+
 conn, _ := db.Conn(ctx)
 conn.Raw(func(conn any) error {
-  ex := conn.(driver.Execer)
-  res, err := ex.Exec(`
+	ex := conn.(driver.Execer)
+	res, err := ex.Exec(`
   UPDATE point SET x = 1 WHERE y = 2;
   UPDATE point SET x = 2 WHERE y = 3;
   `, nil)
-  // Both slices have 2 elements.
-  log.Print(res.(mysql.Result).AllRowsAffected())
-  log.Print(res.(mysql.Result).AllLastInsertIds())
+	if err != nil {
+		return err
+	}
+	// Both slices have 2 elements.
+	log.Print(res.(singlestore.Result).AllRowsAffected())
+	log.Print(res.(singlestore.Result).AllLastInsertIds())
+	return nil
 })
 ```
 
@@ -432,7 +444,7 @@ Default:        none
 
 **Warning**: this setting has no effect for SingleStore. It is used for RSA key exchange with MySQL 8.0+ authentication plugins (`caching_sha2_password`, `sha256_password`). SingleStore uses `mysql_native_password` by default and does not require server public key configuration.
 
-Server public keys can be registered with [`mysql.RegisterServerPubKey`](https://godoc.org/github.com/memsql/go-singlestore-driver#RegisterServerPubKey), which can then be used by the assigned name in the DSN.
+Server public keys can be registered with [`singlestore.RegisterServerPubKey`](https://godoc.org/github.com/singlestore-labs/go-singlestore-driver#RegisterServerPubKey), which can then be used by the assigned name in the DSN.
 Public keys are used to transmit encrypted data, e.g. for authentication.
 If the server's public key is known, it should be set manually to avoid expensive and potentially insecure transmissions of the public key from the server to the client each time it is required.
 
@@ -455,7 +467,7 @@ Valid Values:   true, false, skip-verify, preferred, <name>
 Default:        false
 ```
 
-`tls=true` enables TLS / SSL encrypted connection to the server. Use `skip-verify` if you want to use a self-signed or invalid certificate (server side) or use `preferred` to use TLS only when advertised by the server. This is similar to `skip-verify`, but additionally allows a fallback to a connection which is not encrypted. Neither `skip-verify` nor `preferred` add any reliable security. You can use a custom TLS config after registering it with [`mysql.RegisterTLSConfig`](https://godoc.org/github.com/memsql/go-singlestore-driver#RegisterTLSConfig).
+`tls=true` enables TLS / SSL encrypted connection to the server. Use `skip-verify` if you want to use a self-signed or invalid certificate (server side) or use `preferred` to use TLS only when advertised by the server. This is similar to `skip-verify`, but additionally allows a fallback to a connection which is not encrypted. Neither `skip-verify` nor `preferred` add any reliable security. You can use a custom TLS config after registering it with [`singlestore.RegisterTLSConfig`](https://godoc.org/github.com/singlestore-labs/go-singlestore-driver#RegisterTLSConfig).
 
 
 ##### `writeTimeout`
@@ -575,14 +587,14 @@ When a context is cancelled during query execution and `ctxCancellationEnabled` 
 ### `LOAD DATA LOCAL INFILE` support
 For this feature you need direct access to the package. Therefore you must change the import path (no `_`):
 ```go
-import "github.com/memsql/go-singlestore-driver"
+import "github.com/singlestore-labs/go-singlestore-driver"
 ```
 
-Files must be explicitly allowed by registering them with `mysql.RegisterLocalFile(filepath)` (recommended) or the allowlist check must be deactivated by using the DSN parameter `allowAllFiles=true` ([*Might be insecure!*](https://dev.mysql.com/doc/refman/8.0/en/load-data.html#load-data-local)).
+Files must be explicitly allowed by registering them with `singlestore.RegisterLocalFile(filepath)` (recommended) or the allowlist check must be deactivated by using the DSN parameter `allowAllFiles=true` ([*Might be insecure!*](https://dev.mysql.com/doc/refman/8.0/en/load-data.html#load-data-local)).
 
-To use a `io.Reader` a handler function must be registered with `mysql.RegisterReaderHandler(name, handler)` which returns a `io.Reader` or `io.ReadCloser`. The Reader is available with the filepath `Reader::<name>` then. Choose different names for different handlers and `DeregisterReaderHandler` when you don't need it anymore.
+To use a `io.Reader` a handler function must be registered with `singlestore.RegisterReaderHandler(name, handler)` which returns a `io.Reader` or `io.ReadCloser`. The Reader is available with the filepath `Reader::<name>` then. Choose different names for different handlers and `singlestore.DeregisterReaderHandler` when you don't need it anymore.
 
-See the [godoc of Go-SingleStore-Driver](https://godoc.org/github.com/memsql/go-singlestore-driver "golang singlestore driver documentation") for details.
+See the [godoc of Go-SingleStore-Driver](https://godoc.org/github.com/singlestore-labs/go-singlestore-driver "golang singlestore driver documentation") for details.
 
 
 ### `time.Time` support
@@ -602,7 +614,7 @@ To run the driver tests you may need to adjust the configuration. See the test w
 ---------------------------------------
 
 ## License
-Go-SingleStore-Driver is licensed under the [Mozilla Public License Version 2.0](https://raw.github.com/memsql/go-singlestore-driver/master/LICENSE)
+Go-SingleStore-Driver is licensed under the [Mozilla Public License Version 2.0](https://raw.github.com/singlestore-labs/go-singlestore-driver/master/LICENSE)
 
 Mozilla summarizes the license scope as follows:
 > MPL: The copyleft applies to any files containing MPLed code.
@@ -615,4 +627,4 @@ That means:
 
 Please read the [MPL 2.0 FAQ](https://www.mozilla.org/en-US/MPL/2.0/FAQ/) if you have further questions regarding the license.
 
-You can read the full terms here: [LICENSE](https://raw.github.com/memsql/go-singlestore-driver/master/LICENSE).
+You can read the full terms here: [LICENSE](https://raw.github.com/singlestore-labs/go-singlestore-driver/master/LICENSE).

--- a/auth.go
+++ b/auth.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 import (
 	"crypto/rand"
@@ -52,7 +52,7 @@ var (
 //	}
 //
 //	if rsaPubKey, ok := pub.(*rsa.PublicKey); ok {
-//		mysql.RegisterServerPubKey("mykey", rsaPubKey)
+//		singlestore.RegisterServerPubKey("mykey", rsaPubKey)
 //	} else {
 //		log.Fatal("not a RSA public key")
 //	}

--- a/auth_test.go
+++ b/auth_test.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 import (
 	"bytes"

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 import (
 	"bytes"

--- a/buffer.go
+++ b/buffer.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 import (
 	"io"

--- a/collations.go
+++ b/collations.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 const defaultCollationID = 45 // utf8mb4_general_ci
 const binaryCollationID = 63

--- a/compress.go
+++ b/compress.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 import (
 	"bytes"

--- a/compress_test.go
+++ b/compress_test.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 import (
 	"bytes"

--- a/conncheck.go
+++ b/conncheck.go
@@ -9,7 +9,7 @@
 //go:build linux || darwin || dragonfly || freebsd || netbsd || openbsd || solaris || illumos
 // +build linux darwin dragonfly freebsd netbsd openbsd solaris illumos
 
-package mysql
+package singlestore
 
 import (
 	"errors"

--- a/conncheck_dummy.go
+++ b/conncheck_dummy.go
@@ -9,7 +9,7 @@
 //go:build !linux && !darwin && !dragonfly && !freebsd && !netbsd && !openbsd && !solaris && !illumos
 // +build !linux,!darwin,!dragonfly,!freebsd,!netbsd,!openbsd,!solaris,!illumos
 
-package mysql
+package singlestore
 
 import "net"
 

--- a/conncheck_test.go
+++ b/conncheck_test.go
@@ -9,7 +9,7 @@
 //go:build linux || darwin || dragonfly || freebsd || netbsd || openbsd || solaris || illumos
 // +build linux darwin dragonfly freebsd netbsd openbsd solaris illumos
 
-package mysql
+package singlestore
 
 import (
 	"testing"

--- a/connection.go
+++ b/connection.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 import (
 	"context"

--- a/connection_test.go
+++ b/connection_test.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 import (
 	"context"

--- a/connector.go
+++ b/connector.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 import (
 	"context"
@@ -241,7 +241,7 @@ func isFetchConnectionInfoDisabled(ctx context.Context) bool {
 }
 
 // Driver implements driver.Connector interface.
-// Driver returns &MySQLDriver{}.
+// Driver returns &SingleStoreDriver{}.
 func (c *connector) Driver() driver.Driver {
-	return &MySQLDriver{}
+	return &SingleStoreDriver{}
 }

--- a/connector_test.go
+++ b/connector_test.go
@@ -1,4 +1,4 @@
-package mysql
+package singlestore
 
 import (
 	"context"

--- a/const.go
+++ b/const.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 import "runtime"
 

--- a/const.go
+++ b/const.go
@@ -22,7 +22,7 @@ const (
 	// Connection attributes
 	// See https://dev.mysql.com/doc/refman/8.0/en/performance-schema-connection-attribute-tables.html#performance-schema-connection-attributes-available
 	connAttrClientName      = "_client_name"
-	connAttrClientNameValue = "memsql/go-singlestore-driver"
+	connAttrClientNameValue = "singlestore-labs/go-singlestore-driver"
 	connAttrOS              = "_os"
 	connAttrOSValue         = runtime.GOOS
 	connAttrPlatform        = "_platform"

--- a/driver.go
+++ b/driver.go
@@ -4,17 +4,17 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// Package mysql provides a MySQL driver for Go's database/sql package.
+// package singlestore provides a MySQL driver for Go's database/sql package.
 //
 // The driver should be used via the database/sql package:
 //
 //	import "database/sql"
-//	import _ "github.com/go-sql-driver/mysql"
+//	import _ "github.com/singlestore-labs/go-singlestore-driver"
 //
-//	db, err := sql.Open("mysql", "user:password@/dbname")
+//	db, err := sql.Open("singlestore", "user:password@/dbname")
 //
 // See https://github.com/go-sql-driver/mysql#usage for details
-package mysql
+package singlestore
 
 import (
 	"context"
@@ -24,9 +24,9 @@ import (
 	"sync"
 )
 
-// MySQLDriver is exported to make the driver directly accessible.
+// SingleStoreDriver is exported to make the driver directly accessible.
 // In general the driver is used via the database/sql package.
-type MySQLDriver struct{}
+type SingleStoreDriver struct{}
 
 // DialFunc is a function which can be used to establish the network connection.
 // Custom dial functions must be registered with RegisterDial
@@ -78,7 +78,7 @@ func RegisterDial(network string, dial DialFunc) {
 // Open new Connection.
 // See https://github.com/go-sql-driver/mysql#dsn-data-source-name for how
 // the DSN string is formatted
-func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
+func (d SingleStoreDriver) Open(dsn string) (driver.Conn, error) {
 	cfg, err := ParseDSN(dsn)
 	if err != nil {
 		return nil, err
@@ -88,12 +88,12 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 }
 
 // This variable can be replaced with -ldflags like below:
-// go build "-ldflags=-X github.com/go-sql-driver/mysql.driverName=custom"
-var driverName = "mysql"
+// go build "-ldflags=-X github.com/singlestore-labs/go-singlestore-driver.driverName=custom"
+var driverName = "singlestore"
 
 func init() {
 	if driverName != "" {
-		sql.Register(driverName, &MySQLDriver{})
+		sql.Register(driverName, &SingleStoreDriver{})
 	}
 }
 
@@ -109,7 +109,7 @@ func NewConnector(cfg *Config) (driver.Connector, error) {
 }
 
 // OpenConnector implements driver.DriverContext.
-func (d MySQLDriver) OpenConnector(dsn string) (driver.Connector, error) {
+func (d SingleStoreDriver) OpenConnector(dsn string) (driver.Connector, error) {
 	cfg, err := ParseDSN(dsn)
 	if err != nil {
 		return nil, err

--- a/driver.go
+++ b/driver.go
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// package singlestore provides a SingleStore driver for Go's database/sql package.
+// Package singlestore provides a SingleStore driver for Go's database/sql package.
 //
 // The driver should be used via the database/sql package:
 //

--- a/driver.go
+++ b/driver.go
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// package singlestore provides a MySQL driver for Go's database/sql package.
+// package singlestore provides a SingleStore driver for Go's database/sql package.
 //
 // The driver should be used via the database/sql package:
 //
@@ -13,7 +13,7 @@
 //
 //	db, err := sql.Open("singlestore", "user:password@/dbname")
 //
-// See https://github.com/go-sql-driver/mysql#usage for details
+// See https://github.com/singlestore-labs/go-singlestore-driver#usage for details
 package singlestore
 
 import (
@@ -101,7 +101,7 @@ func init() {
 func NewConnector(cfg *Config) (driver.Connector, error) {
 	cfg = cfg.Clone()
 	// normalize the contents of cfg so calls to NewConnector have the same
-	// behavior as MySQLDriver.OpenConnector
+	// behavior as SingleStoreDriver.OpenConnector
 	if err := cfg.normalize(); err != nil {
 		return nil, err
 	}

--- a/driver_test.go
+++ b/driver_test.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 import (
 	"bytes"
@@ -35,7 +35,7 @@ import (
 )
 
 // This variable can be replaced with -ldflags like below:
-// go test "-ldflags=-X github.com/go-sql-driver/mysql.driverNameTest=custom"
+// go test "-ldflags=-X github.com/singlestore-labs/go-singlestore-driver.driverNameTest=custom"
 var driverNameTest string
 
 func init() {
@@ -225,7 +225,7 @@ func runTestsParallel(t *testing.T, dsn string, tests ...func(dbt *DBTest, table
 			t.Parallel()
 
 			tableName := newTableName(t)
-			db, err := sql.Open("mysql", dsn)
+			db, err := sql.Open("singlestore", dsn)
 			if err != nil {
 				t.Fatalf("error connecting: %s", err.Error())
 			}
@@ -244,7 +244,7 @@ func runTestsParallel(t *testing.T, dsn string, tests ...func(dbt *DBTest, table
 				t.Parallel()
 
 				tableName := newTableName(t)
-				db, err := sql.Open("mysql", dsn2)
+				db, err := sql.Open("singlestore", dsn2)
 				if err != nil {
 					t.Fatalf("error connecting: %s", err.Error())
 				}
@@ -1559,7 +1559,7 @@ func TestReuseClosedConnection(t *testing.T) {
 		t.Skipf("MySQL server not running on %s", netAddr)
 	}
 
-	md := &MySQLDriver{}
+	md := &SingleStoreDriver{}
 	conn, err := md.Open(dsn)
 	if err != nil {
 		t.Fatalf("error connecting: %s", err.Error())
@@ -3373,7 +3373,7 @@ func TestRawBytesAreNotModified(t *testing.T) {
 	})
 }
 
-var _ driver.DriverContext = &MySQLDriver{}
+var _ driver.DriverContext = &SingleStoreDriver{}
 
 type dialCtxKey struct{}
 
@@ -3611,7 +3611,7 @@ func TestErrorInMultiResult(t *testing.T) {
 	// https://github.com/go-sql-driver/mysql/issues/1361
 	var db *sql.DB
 	if _, err := ParseDSN(dsn); err != errInvalidDSNUnsafeCollation {
-		db, err = sql.Open("mysql", dsn)
+		db, err = sql.Open("singlestore", dsn)
 		if err != nil {
 			t.Fatalf("error connecting: %s", err.Error())
 		}

--- a/dsn.go
+++ b/dsn.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 import (
 	"bytes"

--- a/dsn_fuzz_test.go
+++ b/dsn_fuzz_test.go
@@ -1,7 +1,7 @@
 //go:build go1.18
 // +build go1.18
 
-package mysql
+package singlestore
 
 import (
 	"net"

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 import (
 	"crypto/tls"

--- a/errors.go
+++ b/errors.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 import (
 	"errors"
@@ -37,7 +37,7 @@ var (
 	errBadConnNoWrite = errors.New("bad connection")
 )
 
-var defaultLogger = Logger(log.New(os.Stderr, "[mysql] ", log.Ldate|log.Ltime))
+var defaultLogger = Logger(log.New(os.Stderr, "[singlestore] ", log.Ldate|log.Ltime))
 
 // Logger is used to log critical error messages.
 type Logger interface {

--- a/errors_test.go
+++ b/errors_test.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 import (
 	"bytes"

--- a/fields.go
+++ b/fields.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 import (
 	"database/sql"

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module github.com/memsql/go-singlestore-driver
+module github.com/singlestore-labs/go-singlestore-driver
 
-go 1.21.0
+go 1.25.10
 
-require filippo.io/edwards25519 v1.1.1
+require filippo.io/edwards25519 v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/singlestore-labs/go-singlestore-driver
 
-go 1.25.10
+go 1.24.13
 
 require filippo.io/edwards25519 v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/singlestore-labs/go-singlestore-driver
 
-go 1.24.13
+go 1.24.0
 
 require filippo.io/edwards25519 v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-filippo.io/edwards25519 v1.1.1 h1:YpjwWWlNmGIDyXOn8zLzqiD+9TyIlPhGFG96P39uBpw=
-filippo.io/edwards25519 v1.1.1/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
+filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q77mc=

--- a/infile.go
+++ b/infile.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 import (
 	"fmt"
@@ -29,7 +29,7 @@ var (
 // the DSN parameter 'allowAllFiles=true'
 //
 //	filePath := "/home/gopher/data.csv"
-//	mysql.RegisterLocalFile(filePath)
+//	singlestore.RegisterLocalFile(filePath)
 //	err := db.Exec("LOAD DATA LOCAL INFILE '" + filePath + "' INTO TABLE foo")
 //	if err != nil {
 //	...
@@ -57,7 +57,7 @@ func DeregisterLocalFile(filePath string) {
 // If the handler returns a io.ReadCloser Close() is called when the
 // request is finished.
 //
-//	mysql.RegisterReaderHandler("data", func() io.Reader {
+//	singlestore.RegisterReaderHandler("data", func() io.Reader {
 //		var csvReader io.Reader // Some Reader that returns CSV data
 //		... // Open Reader here
 //		return csvReader

--- a/nulltime.go
+++ b/nulltime.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 import (
 	"database/sql"

--- a/nulltime_test.go
+++ b/nulltime_test.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 import (
 	"database/sql"

--- a/packets.go
+++ b/packets.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 import (
 	"bytes"

--- a/packets_test.go
+++ b/packets_test.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 import (
 	"bytes"

--- a/result.go
+++ b/result.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 import "database/sql/driver"
 
@@ -16,7 +16,7 @@ import "database/sql/driver"
 // downcasting the returned result:
 //
 //	res, err := rawConn.Exec(...)
-//	res.(mysql.Result).AllRowsAffected()
+//	res.(singlestore.Result).AllRowsAffected()
 type Result interface {
 	driver.Result
 	// AllRowsAffected returns a slice containing the affected rows for each

--- a/rows.go
+++ b/rows.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 import (
 	"database/sql/driver"

--- a/statement.go
+++ b/statement.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 import (
 	"database/sql/driver"

--- a/statement_test.go
+++ b/statement_test.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 import (
 	"bytes"
@@ -45,7 +45,7 @@ func TestConvertDerivedUnsupportedSlice(t *testing.T) {
 	type derived []int
 
 	_, err := converter{}.ConvertValue(derived{1})
-	if err == nil || err.Error() != "unsupported type mysql.derived, a slice of int" {
+	if err == nil || err.Error() != "unsupported type singlestore.derived, a slice of int" {
 		t.Fatal("Unexpected error", err)
 	}
 }

--- a/transaction.go
+++ b/transaction.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 type mysqlTx struct {
 	mc *mysqlConn

--- a/utils.go
+++ b/utils.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 import (
 	"crypto/tls"
@@ -49,11 +49,11 @@ var (
 //	    log.Fatal(err)
 //	}
 //	clientCert = append(clientCert, certs)
-//	mysql.RegisterTLSConfig("custom", &tls.Config{
+//	singlestore.RegisterTLSConfig("custom", &tls.Config{
 //	    RootCAs: rootCertPool,
 //	    Certificates: clientCert,
 //	})
-//	db, err := sql.Open("mysql", "user@tcp(localhost:3306)/test?tls=custom")
+//	db, err := sql.Open("singlestore", "user@tcp(localhost:3306)/test?tls=custom")
 func RegisterTLSConfig(key string, config *tls.Config) error {
 	if _, isBool := readBool(key); isBool || strings.ToLower(key) == "skip-verify" || strings.ToLower(key) == "preferred" {
 		return fmt.Errorf("key '%s' is reserved", key)
@@ -807,7 +807,7 @@ func namedValueToValue(named []driver.NamedValue) ([]driver.Value, error) {
 	for n, param := range named {
 		if len(param.Name) > 0 {
 			// TODO: support the use of Named Parameters #561
-			return nil, errors.New("mysql: driver does not support the use of Named Parameters")
+			return nil, errors.New("singlestore: driver does not support the use of Named Parameters")
 		}
 		dargs[n] = param.Value
 	}
@@ -825,6 +825,6 @@ func mapIsolationLevel(level driver.IsolationLevel) (string, error) {
 	case sql.LevelSerializable:
 		return "SERIALIZABLE", nil
 	default:
-		return "", fmt.Errorf("mysql: unsupported isolation level: %v", level)
+		return "", fmt.Errorf("singlestore: unsupported isolation level: %v", level)
 	}
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package mysql
+package singlestore
 
 import (
 	"bytes"
@@ -225,7 +225,7 @@ func TestIsolationLevelMapping(t *testing.T) {
 	}
 
 	// check unsupported mapping
-	expectedErr := "mysql: unsupported isolation level: 7"
+	expectedErr := "singlestore: unsupported isolation level: 7"
 	actual, err := mapIsolationLevel(driver.IsolationLevel(sql.LevelLinearizable))
 	if actual != "" || err == nil {
 		t.Fatal("Expected error on unsupported isolation level")


### PR DESCRIPTION
The driver registered with `database/sql` now uses the name `singlestore` instead of `mysql`. Update `sql.Open("mysql", dsn)` to `sql.Open("singlestore", dsn)`. This avoids init-time conflicts when both this module and `github.com/go-sql-driver/mysql` are imported.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking API changes (module path, package name, sql driver name, exported driver type) require coordinated upgrades across every dependent; mis-migration causes runtime registration conflicts or compile failures.
> 
> **Overview**
> This is a **breaking** release that rebrands the driver under SingleStore Labs and avoids `database/sql` init conflicts with `github.com/go-sql-driver/mysql`.
> 
> **Consumers must update:** `go.mod` / imports to `github.com/singlestore-labs/go-singlestore-driver`, package prefix `singlestore` (was `mysql`), `sql.Open("singlestore", dsn)` (was `"mysql"`), and exported type `SingleStoreDriver` (was `MySQLDriver`). Driver-facing strings now use `singlestore:` errors and `[singlestore]` logging; the `_client_name` connection attribute is `singlestore-labs/go-singlestore-driver`.
> 
> **Repo/tooling:** New **MIGRATION.md** and an **Unreleased** **CHANGELOG** section document the migration. **README** examples and godoc links follow the new module. **Minimum Go** is **1.24** (`go.mod`); CI tests **1.24–1.26** and runs **golangci-lint** only on **Go 1.25**. Dependency **edwards25519** bumps to **v1.2.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30643234a1035a7598c77ad66c902604b9d473c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->