### PR TITLE
chore: add release process doc

### DIFF
--- a/.github/scripts/list-release-changes.sh
+++ b/.github/scripts/list-release-changes.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # excluding chore:, test:, and ci: commits.
 
 latest_tag() {
-	git tag -l 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-p[0-9]+)?$' | head -1
+	git tag -l 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-p[0-9]+)?$' | head -1 || true
 }
 
 PREV_TAG="${1:-$(latest_tag)}"
@@ -16,5 +16,7 @@ if [[ -z "${PREV_TAG}" ]]; then
 fi
 
 echo "Changes since ${PREV_TAG}:" >&2
-git log "${PREV_TAG}..HEAD" --pretty=format:'%s' --no-merges \
-	| grep -viE '^(chore|test|ci):' || true
+commits=$(git log "${PREV_TAG}..HEAD" --pretty=format:'%s' --no-merges)
+if [[ -n "${commits}" ]]; then
+	printf '%s\n' "${commits}" | grep -viE '^(chore|test|ci):' || true
+fi

--- a/.github/scripts/list-release-changes.sh
+++ b/.github/scripts/list-release-changes.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# List commit subjects since the latest release tag (vX.Y.Z or vX.Y.Z-pN),
+# excluding chore:, test:, and ci: commits.
+
+latest_tag() {
+	git tag -l 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-p[0-9]+)?$' | head -1
+}
+
+PREV_TAG="${1:-$(latest_tag)}"
+
+if [[ -z "${PREV_TAG}" ]]; then
+	echo "error: no release tag found (expected vX.Y.Z or vX.Y.Z-pN)" >&2
+	exit 1
+fi
+
+echo "Changes since ${PREV_TAG}:" >&2
+git log "${PREV_TAG}..HEAD" --pretty=format:'%s' --no-merges \
+	| grep -viE '^(chore|test|ci):' || true

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,5 @@
-# This is the official list of Go-MySQL-Driver authors for copyright purposes.
+# Official list of Go-SingleStore-Driver authors for copyright purposes.
+# Includes Go-MySQL-Driver authors and SingleStore fork contributors.
 
 # If you are submitting a patch, please add your name or the name of the
 # organization which holds the copyright to this list in alphabetical order.
@@ -17,6 +18,7 @@ Aidan <aidan.liu at pingcap.com>
 Alex Snast <alexsn at fb.com>
 Alexey Palazhchenko <alexey.palazhchenko at gmail.com>
 Andrew Reid <andrew.reid at tixtrack.com>
+Andrii Soluk <isoluchok at gmail.com>
 Animesh Ray <mail.rayanimesh at gmail.com>
 Ariel Mashraki <ariel at mashraki.co.il>
 Arne Hormann <arnehormann at gmail.com>
@@ -101,6 +103,7 @@ Olivier Mengué <dolmen at cpan.org>
 oscarzhao <oscarzhaosl at gmail.com>
 Paul Bonser <misterpib at gmail.com>
 Paulius Lozys <pauliuslozys at gmail.com>
+Pavlo Mishchenko <pmishchenko-ua at singlestore.com>
 Peter Schultz <peter.schultz at classmarkets.com>
 Phil Porada <philporada at gmail.com>
 Rebecca Chin <rchin at pivotal.io>
@@ -154,6 +157,7 @@ Percona LLC
 PingCAP Inc.
 Pivotal Inc.
 Shattered Silicon Ltd.
+SingleStore Inc.
 Stripe Inc.
 ThousandEyes
 Zendesk Inc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-## Unreleased
-
 ## v2.0.0 (2026-06-03)
 
 ### Breaking changes

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Code owners
+*       @pmishchenko-ua @singlestore-labs/connectors

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,62 +1,70 @@
 # Releasing
 
-Production releases use **semver tags** on `master` (for example `v2.0.0`, `v2.0.1`). Go resolves
-versions from these tags; update [CHANGELOG.md](CHANGELOG.md) and related docs, then push a tag.
-
-Older tags like `v1.9.3-p0` used a fork-specific `-pN` suffix. Do **not** use that pattern for new **production**
-releases.
+Production releases use **semver tags** on `master` (for example `v2.0.0`, `v2.0.1`). Go resolves versions from these tags; update [CHANGELOG.md](CHANGELOG.md) and related docs, then push a tag.
 
 ## Steps
 
-### 0. Update Changelog:
+### 1. Update Changelog
 
 - Confirm CI is green on the commit you will tag ([Test workflow](.github/workflows/test.yml)).
-- Move [CHANGELOG.md](CHANGELOG.md) notes from `## Unreleased` into a new section:
+- List commits since the latest release tag (skips `ci:`, `chore:`, and `test:`):
 
-```markdown
-## Unreleased
-
-## vX.Y.Z (YYYY-MM-DD)
-
-- user-facing change (#123)
+```bash
+.github/scripts/list-release-changes.sh
 ```
 
-- Update [README.md](README.md) if this release requires it.
-- Open a Pull Request to `master` with a commit such as `chore: prepare for release X.Y.Z`.
+- Turn the relevant items into user-facing bullets and add a new `## vX.Y.Z (YYYY-MM-DD)` section at the top of [CHANGELOG.md](CHANGELOG.md). Try to match the style of prior entries.
+- Update [README.md](README.md) if needed.
+- Open a PR with a commit such as `chore: prepare for release X.Y.Z`.
 
-### 1. After the PR with update is merged, make sure you are on the latest commit in `master`:
+### 2. Sync with master
+
+After the PR is merged, make sure you are on the latest commit in `master`:
 
 ```bash
 git checkout master
 git pull origin master
 ```
 
-### 2. Tag and push:
+### 3. Tag and push
 
 ```bash
 git tag -a vX.Y.Z -m "Release vX.Y.Z"
 git push origin vX.Y.Z
 ```
 
-Pushing `v*.*.*` triggers [.github/workflows/release.yml](.github/workflows/release.yml): run tests,
-then create a GitHub release (initially marked as a **pre-release**).
+Pushing `v*.*.*` triggers [.github/workflows/release.yml](.github/workflows/release.yml): run tests, then create a GitHub release (initially marked as a **pre-release**).
 
-### 3. Finalize on GitHub
+### 4. Finalize on GitHub
 
-1. Open **Actions → Release** and wait for the workflow to succeed.
+You will need write access to **Releases** to complete this step.
+
+1. Open **Actions -> Release** and wait for the workflow to succeed.
 2. Open the new release under **Releases**.
-3. Edit the release body: summarize user-facing changes, link to the CHANGELOG section, drop
-   `chore:` / CI noise from the auto-generated notes.
+3. Edit the release body: summarize user-facing changes, link to the CHANGELOG section, drop `chore:` / CI noise from the auto-generated notes. Note that the auto-generated notes come from GitHub's release-notes generator and are independent of `list-release-changes.sh` — the script is only an aid for writing CHANGELOG.md in step 1.
 4. Uncheck **Set as a pre-release** and mark it as the latest release.
+
+### 5. Verify the release is resolvable
+
+Confirm the proxy has picked up the new tag:
+
+```bash
+go list -m github.com/singlestore-labs/go-singlestore-driver@vX.Y.Z
+```
+
+It may take a few minutes for [pkg.go.dev](https://pkg.go.dev/github.com/singlestore-labs/go-singlestore-driver) to index the new version.
 
 ## If something goes wrong
 
-- **Tests failed after tagging:** fix `master`, delete the tag on GitHub and locally, then tag again.
-- **Wrong tag or bad release:** delete the tag and GitHub release, then create a new semver tag.
-  Do not force-push or reuse a tag that was already published.
+- **Tests failed after tagging:** fix `master`, delete the tag on GitHub and locally, then tag again. The release.yml workflow always publishes as a pre-release first (see step 4), so the failed run will also leave a pre-release that needs to be deleted.
+- **Wrong tag or bad release:** delete the tag and the (pre-)release on GitHub, then create a new semver tag. Do not force-push or reuse a tag that was already published.
 
 Users install a release with:
 
 ```bash
 go get github.com/singlestore-labs/go-singlestore-driver@vX.Y.Z
 ```
+
+## Background: legacy `-pN` tags
+
+Older tags like `v1.9.3-p0` used a fork-specific `-pN` suffix. Do **not** use that pattern for new production releases.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,62 @@
+# Releasing
+
+Production releases use **semver tags** on `master` (for example `v2.0.0`, `v2.0.1`). Go resolves
+versions from these tags; update [CHANGELOG.md](CHANGELOG.md) and related docs, then push a tag.
+
+Older tags like `v1.9.3-p0` used a fork-specific `-pN` suffix. Do **not** use that pattern for new **production**
+releases.
+
+## Steps
+
+### 0. Update Changelog:
+
+- Confirm CI is green on the commit you will tag ([Test workflow](.github/workflows/test.yml)).
+- Move [CHANGELOG.md](CHANGELOG.md) notes from `## Unreleased` into a new section:
+
+```markdown
+## Unreleased
+
+## vX.Y.Z (YYYY-MM-DD)
+
+- user-facing change (#123)
+```
+
+- Update [README.md](README.md) if this release requires it.
+- Open a Pull Request to `master` with a commit such as `chore: prepare for release X.Y.Z`.
+
+### 1. After the PR with update is merged, make sure you are on the latest commit in `master`:
+
+```bash
+git checkout master
+git pull origin master
+```
+
+### 2. Tag and push:
+
+```bash
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+Pushing `v*.*.*` triggers [.github/workflows/release.yml](.github/workflows/release.yml): run tests,
+then create a GitHub release (initially marked as a **pre-release**).
+
+### 3. Finalize on GitHub
+
+1. Open **Actions → Release** and wait for the workflow to succeed.
+2. Open the new release under **Releases**.
+3. Edit the release body: summarize user-facing changes, link to the CHANGELOG section, drop
+   `chore:` / CI noise from the auto-generated notes.
+4. Uncheck **Set as a pre-release** and mark it as the latest release.
+
+## If something goes wrong
+
+- **Tests failed after tagging:** fix `master`, delete the tag on GitHub and locally, then tag again.
+- **Wrong tag or bad release:** delete the tag and GitHub release, then create a new semver tag.
+  Do not force-push or reuse a tag that was already published.
+
+Users install a release with:
+
+```bash
+go get github.com/singlestore-labs/go-singlestore-driver@vX.Y.Z
+```


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation, metadata, and a read-only git helper script only; no driver or runtime behavior changes.
> 
> **Overview**
> Adds **release engineering** docs and tooling so maintainers can ship semver tags consistently.
> 
> **`RELEASING.md`** documents the full flow: prep CHANGELOG via a helper script, merge to `master`, tag `vX.Y.Z`, let `.github/workflows/release.yml` create a pre-release, then finalize notes on GitHub and verify with `go list -m`. It also covers rollback and notes that legacy `vX.Y.Z-pN` tags should not be used for new releases.
> 
> **`.github/scripts/list-release-changes.sh`** finds the latest `v*.*.*` (or `-pN`) tag and prints non-merge commit subjects since then, excluding `chore:`, `test:`, and `ci:` prefixes.
> 
> Supporting updates: new **`CODEOWNERS`** (`@pmishchenko-ua`, `@singlestore-labs/connectors`), **`AUTHORS`** header and SingleStore contributors, and **`CHANGELOG.md`** drops the empty **Unreleased** section now that `v2.0.0` is the top entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 882772ec6de304c3b45be9ad5ed0d14c2705ab85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->