### PR TITLE
fix: update module path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## v2.0.0 (2026-06-03)
+## v2.0.1 (2026-06-08)
 
 ### Breaking changes
 
-- The module path moved from `github.com/memsql/go-singlestore-driver` to `github.com/singlestore-labs/go-singlestore-driver`. Update import paths and `go.mod` accordingly. See [MIGRATION.md](MIGRATION.md).
+- The module path moved from `github.com/memsql/go-singlestore-driver` to `github.com/singlestore-labs/go-singlestore-driver/v2`. Update import paths and `go.mod` accordingly. See [MIGRATION.md](MIGRATION.md).
 - The Go package name is now `singlestore` (was `mysql`). Named imports must be updated; the exported driver type is renamed `MySQLDriver` -> `SingleStoreDriver`.
 - The driver registered with `database/sql` now uses the name `singlestore` instead of `mysql`. Update `sql.Open("mysql", dsn)` to `sql.Open("singlestore", dsn)`. This avoids init-time conflicts when both this module and `github.com/go-sql-driver/mysql` are imported.
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -15,7 +15,7 @@ This driver registers with `database/sql` as **`singlestore`**, package name is 
 
 2. **Blank import** registers the driver. Replace `github.com/go-sql-driver/mysql` or `github.com/memsql/go-singlestore-driver` with
    ```go
-   _ "github.com/singlestore-labs/go-singlestore-driver"
+   _ "github.com/singlestore-labs/go-singlestore-driver/v2"
    ```
    The blank import does not bind the package name, so it does **not** conflict with a named import of the same module elsewhere in the file (see point 4 and the package-name collision note below).
 
@@ -26,7 +26,7 @@ This driver registers with `database/sql` as **`singlestore`**, package name is 
 
 4. **Named imports** — rename the package prefix on symbols from this module:
    ```go
-   import "github.com/singlestore-labs/go-singlestore-driver" // package singlestore
+   import "github.com/singlestore-labs/go-singlestore-driver/v2" // package singlestore
 
    singlestore.ParseDSN(dsn)
    singlestore.NewConnector(cfg)
@@ -37,8 +37,8 @@ This driver registers with `database/sql` as **`singlestore`**, package name is 
    **Package-name collision.** If your own code lives in a package named `singlestore` (common in repos that wrap this driver), the bare `singlestore.X` form is ambiguous. Use an import alias instead:
    ```go
    import (
-       _ "github.com/singlestore-labs/go-singlestore-driver" // register driver
-       s2driver "github.com/singlestore-labs/go-singlestore-driver"
+       _ "github.com/singlestore-labs/go-singlestore-driver/v2" // register driver
+       s2driver "github.com/singlestore-labs/go-singlestore-driver/v2"
    )
 
    cfg, err := s2driver.ParseDSN(dsn)

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,7 +8,7 @@ This driver registers with `database/sql` as **`singlestore`**, package name is 
 1. **Module** — pin the new module path (optional; `goimports` / `go build` can add it once imports exist):
    ```bash
    # Pin a released semver tag:
-   go get github.com/singlestore-labs/go-singlestore-driver@v2.0.0
+   go get github.com/singlestore-labs/go-singlestore-driver@v2.0.1
    # or pin a specific commit (Go produces a v0.0.0-<date>-<sha> pseudo-version):
    go get github.com/singlestore-labs/go-singlestore-driver@abcdef1234567890
    ```

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This driver is a fork of [go-sql-driver/mysql](https://github.com/go-sql-driver/
 ## Installation
 Install the package to your [$GOPATH](https://github.com/golang/go/wiki/GOPATH "GOPATH") with the [go tool](https://golang.org/cmd/go/ "go command") from shell:
 ```bash
-go get -u github.com/singlestore-labs/go-singlestore-driver
+go get -u github.com/singlestore-labs/go-singlestore-driver/v2
 ```
 Make sure [Git is installed](https://git-scm.com/downloads) on your machine and in your system's `PATH`.
 
@@ -84,7 +84,7 @@ import (
 	"database/sql"
 	"time"
 
-	_ "github.com/singlestore-labs/go-singlestore-driver"
+	_ "github.com/singlestore-labs/go-singlestore-driver/v2"
 )
 
 // ...
@@ -353,7 +353,7 @@ import (
 	"database/sql/driver"
 	"log"
 
-	"github.com/singlestore-labs/go-singlestore-driver"
+	"github.com/singlestore-labs/go-singlestore-driver/v2"
 )
 
 conn, _ := db.Conn(ctx)
@@ -587,7 +587,7 @@ When a context is cancelled during query execution and `ctxCancellationEnabled` 
 ### `LOAD DATA LOCAL INFILE` support
 For this feature you need direct access to the package. Therefore you must change the import path (no `_`):
 ```go
-import "github.com/singlestore-labs/go-singlestore-driver"
+import "github.com/singlestore-labs/go-singlestore-driver/v2"
 ```
 
 Files must be explicitly allowed by registering them with `singlestore.RegisterLocalFile(filepath)` (recommended) or the allowlist check must be deactivated by using the DSN parameter `allowAllFiles=true` ([*Might be insecure!*](https://dev.mysql.com/doc/refman/8.0/en/load-data.html#load-data-local)).

--- a/driver.go
+++ b/driver.go
@@ -9,7 +9,7 @@
 // The driver should be used via the database/sql package:
 //
 //	import "database/sql"
-//	import _ "github.com/singlestore-labs/go-singlestore-driver"
+//	import _ "github.com/singlestore-labs/go-singlestore-driver/v2"
 //
 //	db, err := sql.Open("singlestore", "user:password@/dbname")
 //

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/singlestore-labs/go-singlestore-driver
+module github.com/singlestore-labs/go-singlestore-driver/v2
 
 go 1.24.0
 


### PR DESCRIPTION
### Description
Tags v2.x.y are picked up by `go get` only if the module is declared with `v2` suffix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Consumers on the pre-fix module path must change imports and `go.mod`; behavior is unchanged but migration is mandatory for correct versioning.
> 
> **Overview**
> **Fixes Go module path for v2 releases** by appending `/v2` to `github.com/singlestore-labs/go-singlestore-driver` in `go.mod` and every documented import (`README`, `MIGRATION.md`, `driver.go` package comment).
> 
> **Release notes** move the changelog entry to **v2.0.1 (2026-06-08)** and state that consumers must use the `/v2` module path so `go get` resolves `v2.x.y` tags correctly per Go’s major-version rules.
> 
> No driver runtime or API behavior changes—only module identity and documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 100dc89b75c7d468d3c1c642a35c9cfc7f800b75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->